### PR TITLE
Add more tests, minor compatibility changes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,20 @@ var https = require('https');
 var NodeXHREventTarget = require('./node-xhr-event-target');
 
 /**
+ * Currently-supported response types.
+ *
+ * @private
+ * @readonly
+ * @type {Object<String, Boolean>}
+ */
+var supportedResponseTypes = Object.freeze({
+  /** Text response (implicit) */
+  '': true,
+  /** Text response */
+  'text': true
+});
+
+/**
  * Makes a request using either `http.request` or `https.request`, depending
  * on the value of `opts.protocol`.
  *
@@ -106,6 +120,16 @@ module.exports = function () {
    * @type {?http.IncomingMessage}
    */
   this._resp = null;
+
+  /**
+   * The type of the response. Currently, only `''` and `'text'` are
+   * supported, which both indicate the response should be a `String`.
+   *
+   * @private
+   * @type {String}
+   * @default ''
+   */
+  this._responseType = '';
 
   /**
    * The current response text, or `null` if the request hasn't been sent or
@@ -241,7 +265,16 @@ NodeHttpXHR.prototype = Object.create(
      * @type {String}
      * @default ''
      */
-    responseType: { value: '', writable: true },
+    responseType: {
+      get: function () { return this._responseType; },
+      set: function (responseType) {
+        if (!(responseType in supportedResponseTypes)) {
+          return;
+        }
+
+        this._responseType = responseType;
+      }
+    },
     /**
      * The response, encoded according to {@link
      * module:node-http-xhr#responseType
@@ -260,7 +293,7 @@ NodeHttpXHR.prototype = Object.create(
     response: {
       get: function getResponse() {
         var type = this.responseType;
-        if (type !== '' && type !== 'text') {
+        if (!(type in supportedResponseTypes)) {
           throw new Error('Unsupported responseType "' + type + '"');
         }
 
@@ -270,7 +303,7 @@ NodeHttpXHR.prototype = Object.create(
     /**
      * The response body as a string.
      *
-     * If `send())` has not been called yet, this is `null`.
+     * If `send()` has not been called yet, this is `null`.
      *
      * This will be incomplete until the response actually finishes.
      *
@@ -463,6 +496,7 @@ NodeHttpXHR.prototype.send = function (data) {
   req.on('aborted', onAbort);
 
   req.on('timeout', function onTimeout() {
+    this._setReadyState(this.DONE);
     this.dispatchEvent({
       type: 'timeout'
     });


### PR DESCRIPTION
- On timeout, `readyState` is set to `DONE`
- Writing an unsupported value to `responseType` now fails silently